### PR TITLE
Create jukeboxes

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,3 +1,6 @@
+exit
+user_paramsexit
+user_params
 continue
 JSON.parse(f)
 f = playlist.rspotify.to_json

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -27,8 +27,12 @@ class PlaylistsController < ApplicationController
 
   def update
     playlist = Playlist.find_by(id: params[:id])
-    playlist.update(playlist_params)
-    redirect_to playlist
+    if playlist.update(playlist_params)
+      redirect_to playlist
+    else
+      flash[:alert] = playlist.errors.full_messages
+    redirect_to edit_playlist_path(playlist)
+    end
   end
 
   def destroy
@@ -57,7 +61,7 @@ class PlaylistsController < ApplicationController
   private
 
   def playlist_params
-    params.require(:playlist).permit(:name)
+    params.require(:playlist).permit(:name, :link_name)
   end
 
   ### Do we need this ??? a lot of extra controller logic to account for duplicated playlist logic. maybe it should go somewere else?

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -14,7 +14,7 @@ class Playlist < ActiveRecord::Base
     self.spotify_id = params.id
   end
 
-  def link_name
+  def party_path
     link_name = self[:link_name]
     return nil unless link_name
     link_name.downcase.gsub(/[\s]/,"-")

--- a/app/views/playlists/show.html.erb
+++ b/app/views/playlists/show.html.erb
@@ -25,6 +25,9 @@
         Deactivate 
         <i class="material-icons">volume_off</i>
       <% end %>
+      <%= link_to "at/#{@playlist.party_path}", class: "waves-effect waves-light btn darken-2" do %> 
+        Party Link: at/<%= @playlist.party_path %>
+      <% end %>
     <% else %>
       <%= link_to activate_playlist_path, class: "waves-effect waves-light btn light-blue darken-2" do %> 
           Activate 

--- a/test/features/playlists_dashboard_test.rb
+++ b/test/features/playlists_dashboard_test.rb
@@ -16,7 +16,7 @@ feature "Logging in" do
     visit root_path
     mock_oauth(:grace)
 
-    RSpotify::User.stub :find, RSpotify::User.new(USER_PARAMS[:grace]) do
+    RSpotify::User.stub :find, RSpotify::User.new(PARAMS[:users][:grace]) do
       page.find("#top-nav-login").click
     end
     page.must_have_content("Grace Hopper")

--- a/test/features/starting_a_party_test.rb
+++ b/test/features/starting_a_party_test.rb
@@ -22,10 +22,10 @@ feature "Throwing a party" do
   end
 
   scenario "navigate to playlist show page from the dashboard and activate" do
-    skip
+    # skip
     click_link "The Jams"
     click_on "Activate"
-    page.must_have_content("Party Link: at/#{playlists(:basic).link_name}")
+    page.must_have_content("Party Link: at/#{playlists(:basic).party_path}")
   end
 
   scenario "User tries to activate a playlist with no link_name - they are redirected to #show page" do

--- a/test/features/starting_a_party_test.rb
+++ b/test/features/starting_a_party_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require_relative "../support/rspotify_stub_helper"
-
 include RSpotifyStubHelper
 
 feature "Throwing a party" do
@@ -9,12 +8,12 @@ feature "Throwing a party" do
   end
 
   scenario "User creates a new playlist from the dashboard" do
-    name = PLAYLIST_PARAMS['name']
+    name = PARAMS[:playlist]['name']
 
     click_link "New playlist"
     fill_in "Name", with: name
 
-    stub_playlist  do
+    stub_create_playlist  do
       click_on "Submit"
     end
 

--- a/test/features/starting_a_party_test.rb
+++ b/test/features/starting_a_party_test.rb
@@ -23,7 +23,9 @@ feature "Throwing a party" do
   scenario "navigate to playlist show page from the dashboard and activate" do
     # skip
     click_link "The Jams"
+    save_and_open_page
     click_on "Activate"
+    save_and_open_page
     page.must_have_content("Party Link: at/#{playlists(:basic).party_path}")
   end
 

--- a/test/fixtures/playlists.yml
+++ b/test/fixtures/playlists.yml
@@ -3,12 +3,12 @@ basic:
   name: The Jams
   link_name: "hangin with misses hopper"
   user: grace
-  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_YAML %>
+  # spotify_hash: <%#= RSpotifyStubHelper::PLAYLIST_YAML %>
 
 nameless:
   name: Nameless Jams
   user: grace
-  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_YAML%>
+  # spotify_hash: <%#= RSpotifyStubHelper::PLAYLIST_YAML%>
 
 
 

--- a/test/fixtures/playlists.yml
+++ b/test/fixtures/playlists.yml
@@ -3,12 +3,12 @@ basic:
   name: The Jams
   link_name: "hangin with misses hopper"
   user: grace
-  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_yaml %>
+  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_YAML %>
 
 nameless:
   name: Nameless Jams
   user: grace
-  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_yaml %>
+  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_YAML%>
 
 
 

--- a/test/fixtures/playlists.yml
+++ b/test/fixtures/playlists.yml
@@ -3,6 +3,7 @@ basic:
   name: The Jams
   link_name: "hangin with misses hopper"
   user: grace
+  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_json %>
 
 nameless:
   name: Nameless Jams

--- a/test/fixtures/playlists.yml
+++ b/test/fixtures/playlists.yml
@@ -3,12 +3,12 @@ basic:
   name: The Jams
   link_name: "hangin with misses hopper"
   user: grace
-  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_json %>
+  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_yaml %>
 
 nameless:
   name: Nameless Jams
   user: grace
-  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_json %>
+  spotify_hash: <%= RSpotifyStubHelper::PLAYLIST_SPOTIFY_HASH.to_yaml %>
 
 
 

--- a/test/fixtures/playlists.yml
+++ b/test/fixtures/playlists.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 basic: 
   name: The Jams
-  link_name: "hangin with misses hopper"
+  link_name: "hangin with ms hopper"
   user: grace
   # spotify_hash: <%#= RSpotifyStubHelper::PLAYLIST_YAML %>
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,7 +12,7 @@ grace:
   display_name: Grace Hopper
   email:  test@test.com
   profile_url: http://open.spotify.com/test
-  spotify_hash: <%=RSpotifyStubHelper::USER_SPOTIFY_HASH.to_json %>
+  spotify_hash: <%=RSpotifyStubHelper::USER_YAML %>
   image: "https://scontent.xx.fbcdn.net/hprofile-xtp1/v/t1.0-1/p200x200/12109254_10153317472678737_2420135860526267916_n.jpg?oh=203c987de73a00ee3239cf4c1a377261&oe=56B0D160"
 # # column: value
 # #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,8 +12,9 @@ grace:
   display_name: Grace Hopper
   email:  test@test.com
   profile_url: http://open.spotify.com/test
-  spotify_hash: <%=RSpotifyStubHelper::USER_YAML %>
   image: "https://scontent.xx.fbcdn.net/hprofile-xtp1/v/t1.0-1/p200x200/12109254_10153317472678737_2420135860526267916_n.jpg?oh=203c987de73a00ee3239cf4c1a377261&oe=56B0D160"
+  # spotify_hash: <%#=RSpotifyStubHelper::USER_YAML %>
+  
 # # column: value
 # #
 # two: {}

--- a/test/models/playlist_test.rb
+++ b/test/models/playlist_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+include RSpotifyStubHelper
 
 class PlaylistTest < ActiveSupport::TestCase
   test "playlist has a name" do
@@ -18,10 +19,9 @@ class PlaylistTest < ActiveSupport::TestCase
   end
 
   test "#spotify_hash returns a hash if valid JSON string is stored in object" do 
-    # RSpotify::Playlist.stub :find, RSpotify::Playlist.new(PLAYLIST_PARAMS) do
       test_list = playlists(:basic)
-      assert_equal test_list.spotify_hash.class, Hash
-    # end
+      test_list.spotify_hash = spotify_hash_for :playlist
+      assert_instance_of Hash, test_list.spotify_hash
   end
 
 

--- a/test/models/playlist_test.rb
+++ b/test/models/playlist_test.rb
@@ -18,15 +18,11 @@ class PlaylistTest < ActiveSupport::TestCase
   end
 
   test "#spotify_hash returns a hash if valid JSON string is stored in object" do 
-    test_list = playlists(:basic)
-    assert_equal test_list.spotify_hash.class, Hash
+    # RSpotify::Playlist.stub :find, RSpotify::Playlist.new(PLAYLIST_PARAMS) do
+      test_list = playlists(:basic)
+      assert_equal test_list.spotify_hash.class, Hash
+    # end
   end
-
-  # test "#link_name returns nil if there is no link_name" do 
-  #   skip
-  #   test_list = playlists(:nameless)
-  #   assert_nil test_list.link_name
-  # end
 
 
 end

--- a/test/models/playlist_test.rb
+++ b/test/models/playlist_test.rb
@@ -7,9 +7,9 @@ class PlaylistTest < ActiveSupport::TestCase
 
 
 
-  test "#link_name returns a nice link-friendly hyphenated string" do 
+  test "#party_path returns a nice link-friendly hyphenated string" do 
     test_list = playlists(:basic)
-    refute_equal test_list.link_name, test_list[:link_name]
+    refute_equal test_list.party_path, test_list[:link_name]
   end
 
   test "#link_name returns nil if there is no link_name" do 
@@ -19,13 +19,14 @@ class PlaylistTest < ActiveSupport::TestCase
 
   test "#spotify_hash returns a hash if valid JSON string is stored in object" do 
     test_list = playlists(:basic)
-    refute_equal test_list.link_name, test_list[:link_name]
+    assert_equal test_list.spotify_hash.class, Hash
   end
 
-  test "#spotify_hash returns nil if there is no link_name" do 
-    test_list = playlists(:nameless)
-    assert_nil test_list.link_name
-  end
+  # test "#link_name returns nil if there is no link_name" do 
+  #   skip
+  #   test_list = playlists(:nameless)
+  #   assert_nil test_list.link_name
+  # end
 
 
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+include RSpotifyStubHelper
 
 class UserTest < ActiveSupport::TestCase
   # test "the truth" do
@@ -10,7 +11,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "#spotify_hash returns a hash if valid JSON string is stored in object" do 
     test_user = users(:grace)
-    assert_equal test_user.spotify_hash.class, Hash
+    test_user.spotify_hash = spotify_hash_for :grace
+    assert_instance_of Hash, test_user.spotify_hash
   end
 
   # test "#spotify_hash returns nil if there is no link_name" do 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,14 +9,14 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "#spotify_hash returns a hash if valid JSON string is stored in object" do 
-    test_list = playlists(:basic)
-    refute_equal test_list.link_name, test_list[:link_name]
+    test_user = users(:grace)
+    assert_equal test_user.spotify_hash.class, Hash
   end
 
-  test "#spotify_hash returns nil if there is no link_name" do 
-    test_list = playlists(:nameless)
-    assert_nil test_list.link_name
-  end
+  # test "#spotify_hash returns nil if there is no link_name" do 
+  #   test_list = playlists(:nameless)
+  #   assert_nil test_list.link_name
+  # end
 
 
 end

--- a/test/support/rspotify_stub_helper.rb
+++ b/test/support/rspotify_stub_helper.rb
@@ -67,8 +67,11 @@ module RSpotifyStubHelper
       "path"=>"users/discgrace/playlists/2Vsiq5g9YRAX9lK6P1ejOE"
     }
 
-    PLAYLIST_SPOTIFY_HASH = PLAYLIST_PARAMS.as_json
-    USER_SPOTIFY_HASH = USER_PARAMS.as_json
+  PLAYLIST_SPOTIFY_HASH = PLAYLIST_PARAMS.as_json
+  USER_SPOTIFY_HASH = USER_PARAMS.as_json
+
+  PLAYLIST_YAML = PLAYLIST_SPOTIFY_HASH.instance_variables.inject({}) { |hash,var| hash[var.to_s.delete("@")] = PLAYLIST_PARAMS.instance_variable_get(var); hash }.to_yaml
+  USER_YAML = PLAYLIST_SPOTIFY_HASH.instance_variables.inject({}) { |hash,var| hash[var.to_s.delete("@")] = USER_PARAMS.instance_variable_get(var); hash }.to_yaml
 
   # we need to mock both oauth and rspotify#find for login
   def login_with_oauth(user = :grace)

--- a/test/support/rspotify_stub_helper.rb
+++ b/test/support/rspotify_stub_helper.rb
@@ -1,90 +1,95 @@
 module RSpotifyStubHelper
 
   # Rspotify's Omniauth returns something from this hash
-    USER_PARAMS = {
-      :grace => {
-        :refresh_token => "AQCcIUDrh9CJuKnNgenS1lNlO95nGkNZVQbqHB4QgS7g-jcG8tAwkdn14kjMHMB-h0MMlJ3Y6pQ7RxD6tU8Qc2rtpNfqkpm73ZduDwq0aSjwFktSxoFDkWixyWeHfhmq_ts",
-        :token => "BQAVIVJl4DRWezsup9HtB6FSi7oyi1wz_LNLtZq4TTFWU5qvjVDsqUvhJPINkta5bb20f_KHwzr4_lxohvNGN1tAyCliel5-aL1ou9jiaOwr3TZiiwRH1DWst_y_MsgSa2QHKrVohsu0oSR2Giwq0zwLv347mZnQbKy1GsafX1JW6USFawPJ9H0kXPtwEX6TGwZmeL77z7PJdoU",
-        :info => {
-          :id => 'discgrace',
-          :display_name => "Grace Hopper",
-          :email => 'test@test.com',
-          :images => [{
-            "height"=>nil,
-            "url"=>"https://scontent.xx.fbcdn.net/hprofile-xtp1/v/t1.0-1/p200x200/12109254_10153317472678737_2420135860526267916_n.jpg?oh=203c987de73a00ee3239cf4c1a377261&oe=56B0D160",
-            "width"=>nil
-          }],
-          :birthdate => nil,
-          :country => nil,
-          :uri => nil,
-          :external_urls => {
-            "spotify"=>"https://open.spotify.com/user/erik"
+    PARAMS = {
+      :users => {
+        :grace => {
+          :refresh_token => "AQCcIUDrh9CJuKnNgenS1lNlO95nGkNZVQbqHB4QgS7g-jcG8tAwkdn14kjMHMB-h0MMlJ3Y6pQ7RxD6tU8Qc2rtpNfqkpm73ZduDwq0aSjwFktSxoFDkWixyWeHfhmq_ts",
+          :token => "BQAVIVJl4DRWezsup9HtB6FSi7oyi1wz_LNLtZq4TTFWU5qvjVDsqUvhJPINkta5bb20f_KHwzr4_lxohvNGN1tAyCliel5-aL1ou9jiaOwr3TZiiwRH1DWst_y_MsgSa2QHKrVohsu0oSR2Giwq0zwLv347mZnQbKy1GsafX1JW6USFawPJ9H0kXPtwEX6TGwZmeL77z7PJdoU",
+          :info => {
+            :id => 'discgrace',
+            :display_name => "Grace Hopper",
+            :email => 'test@test.com',
+            :images => [{
+              "height"=>nil,
+              "url"=>"https://scontent.xx.fbcdn.net/hprofile-xtp1/v/t1.0-1/p200x200/12109254_10153317472678737_2420135860526267916_n.jpg?oh=203c987de73a00ee3239cf4c1a377261&oe=56B0D160",
+              "width"=>nil
+            }],
+            :birthdate => nil,
+            :country => nil,
+            :uri => nil,
+            :external_urls => {
+              "spotify"=>"https://open.spotify.com/user/erik"
+            }
           }
         }
+      },
+      :playlist => {
+        "collaborative"=>false,
+        "description"=>nil,
+        "followers"=>{
+            "href"=>nil, 
+            "total"=>0
+          },
+        "images"=>[],
+        "name"=>"Space Jams",
+        "public"=>true,
+        "snapshot_id"=>"2BfKsGBoCiEZiV96mQcDGXVQ4NuU8tvybnDbDhX5wQAeHS0ZmtyYk1K6jV1EW1rY", 
+        "total"=>0, 
+        "owner"=>{
+          "birthdate"=>nil,
+          "country"=>nil,
+          "display_name"=>nil,
+          "email"=>nil,
+          "followers"=>nil,
+          "images"=>nil,
+          "product"=>nil, 
+          "external_urls"=>{"spotify"=>"http://open.spotify.com/user/discgrace"},
+          "href"=>"https://api.spotify.com/v1/users/discgrace",
+          "id"=>"discgrace", 
+          "type"=>"user",
+          "uri"=>"spotify:user:discgrace"
+        },
+        "tracks" => {
+          "total" => 0
+        },
+        "tracks_cache"=>[],
+        "tracks_added_at"=>{},
+        "tracks_added_by"=>{},
+        "tracks_is_local"=>{},
+        "external_urls"=>{
+          "spotify"=>"http://open.spotify.com/user/discgrace/playlist/2Vsiq5g9YRAX9lK6P1ejOE"
+          }, 
+        "href"=>"https://api.spotify.com/v1/users/discgrace/playlists/2Vsiq5g9YRAX9lK6P1ejOE",
+        "id"=>"2Vsiq5g9YRAX9lK6P1ejOE",
+        "type"=>"playlist",
+        "uri"=>"spotify:user:discgrace:playlist:2Vsiq5g9YRAX9lK6P1ejOE",
+        "path"=>"users/discgrace/playlists/2Vsiq5g9YRAX9lK6P1ejOE"
       }
     }
 
-    PLAYLIST_PARAMS = {
-      "collaborative"=>false,
-      "description"=>nil,
-      "followers"=>{
-          "href"=>nil, 
-          "total"=>0
-        },
-      "images"=>[],
-      "name"=>"Space Jams",
-      "public"=>true,
-      "snapshot_id"=>"2BfKsGBoCiEZiV96mQcDGXVQ4NuU8tvybnDbDhX5wQAeHS0ZmtyYk1K6jV1EW1rY", 
-      "total"=>0, 
-      "owner"=>{
-        "birthdate"=>nil,
-        "country"=>nil,
-        "display_name"=>nil,
-        "email"=>nil,
-        "followers"=>nil,
-        "images"=>nil,
-        "product"=>nil, 
-        "external_urls"=>{"spotify"=>"http://open.spotify.com/user/discgrace"},
-        "href"=>"https://api.spotify.com/v1/users/discgrace",
-        "id"=>"discgrace", 
-        "type"=>"user",
-        "uri"=>"spotify:user:discgrace"
-      },
-      "tracks" => {
-        "total" => 0
-      },
-      "tracks_cache"=>[],
-      "tracks_added_at"=>{},
-      "tracks_added_by"=>{},
-      "tracks_is_local"=>{},
-      "external_urls"=>{
-        "spotify"=>"http://open.spotify.com/user/discgrace/playlist/2Vsiq5g9YRAX9lK6P1ejOE"
-        }, 
-      "href"=>"https://api.spotify.com/v1/users/discgrace/playlists/2Vsiq5g9YRAX9lK6P1ejOE",
-      "id"=>"2Vsiq5g9YRAX9lK6P1ejOE",
-      "type"=>"playlist",
-      "uri"=>"spotify:user:discgrace:playlist:2Vsiq5g9YRAX9lK6P1ejOE",
-      "path"=>"users/discgrace/playlists/2Vsiq5g9YRAX9lK6P1ejOE"
-    }
+  def spotify_hash_for(whom)
+    return PARAMS[whom].to_json if whom == :playlist
+    PARAMS[:users].fetch(whom).to_json
+  end
+  # PLAYLIST_SPOTIFY_HASH = PLAYLIST_PARAMS.to_json
+  # USER_SPOTIFY_HASH = USER_PARAMS.to_json
 
-  PLAYLIST_SPOTIFY_HASH = PLAYLIST_PARAMS.as_json
-  USER_SPOTIFY_HASH = USER_PARAMS.as_json
-
-  PLAYLIST_YAML = PLAYLIST_SPOTIFY_HASH.instance_variables.inject({}) { |hash,var| hash[var.to_s.delete("@")] = PLAYLIST_PARAMS.instance_variable_get(var); hash }.to_yaml
-  USER_YAML = PLAYLIST_SPOTIFY_HASH.instance_variables.inject({}) { |hash,var| hash[var.to_s.delete("@")] = USER_PARAMS.instance_variable_get(var); hash }.to_yaml
+  # PLAYLIST_YAML = PLAYLIST_SPOTIFY_HASH.instance_variables.inject({}) { |hash,var| hash[var.to_s.delete("@")] = PLAYLIST_PARAMS.instance_variable_get(var); hash }.to_yaml
+  # USER_YAML = PLAYLIST_SPOTIFY_HASH.instance_variables.inject({}) { |hash,var| hash[var.to_s.delete("@")] = USER_PARAMS.instance_variable_get(var); hash }.to_yaml
 
   # we need to mock both oauth and rspotify#find for login
   def login_with_oauth(user = :grace)
     mock_oauth(user)
 
-    RSpotify::User.stub :find, RSpotify::User.new(USER_PARAMS[user]) do
+    RSpotify::User.stub :find, RSpotify::User.new(PARAMS[:users][user]) do
       visit "/auth/spotify"
     end
   end
 
-  def stub_playlist
-    RSpotify::User.stub_any_instance :create_playlist!, RSpotify::Playlist.new(PLAYLIST_PARAMS) do
-      RSpotify::User.stub :find, RSpotify::User.new(USER_PARAMS[:grace]) do
+  def stub_create_playlist
+    RSpotify::User.stub_any_instance :create_playlist!, RSpotify::Playlist.new(PARAMS[:playlist]) do
+      RSpotify::User.stub :find, RSpotify::User.new(PARAMS[:users][:grace]) do
         yield
       end
     end
@@ -92,11 +97,11 @@ module RSpotifyStubHelper
 
 
   def mock_oauth(user)
-    OmniAuth.config.add_mock :spotify, RSpotifyStubHelper::USER_PARAMS[user]
+    OmniAuth.config.add_mock :spotify, RSpotifyStubHelper::PARAMS[:users][user]
   end
 
   def user_stub(user)
-    RSpotify::User.new(USER_PARAMS[user])
+    RSpotify::User.new(PARAMS[:user][user])
   end
 
 


### PR DESCRIPTION
fixed stubs. not totally happy with it, but the crux of the issue was that I was trying to load entire hashes into erb yaml (the spotify_hash via rspotify stub helpers module in testing)- trying to inject that into the yaml was causing havoc, and it's just a limitation I think of our current way of setting this up with activerecord models that mirror rspotify api models... for lack of a better way to put it.

thoughtbot gives one alternative which is to stub out your external services using a separate gem, so we could make api calls and just specify what we will return in test helpers. I actually think this would be better:
https://robots.thoughtbot.com/how-to-stub-external-services-in-tests

thus we don't have to stub out the innerworkings of rspotify (the gem itself tests against real-world users and playlists) but just specify a few standard api responses.

especially as we move into track listings and such that might become more of an issue.
